### PR TITLE
Add .gitignore and fix stop_lsp_on_tab_leave wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.testenv

--- a/lua/bufstate/init.lua
+++ b/lua/bufstate/init.lua
@@ -263,6 +263,7 @@ function M.setup(_opts)
 
 	-- LSP config
 	local stop_lsp_on_session_load = _opts.stop_lsp_on_session_load ~= false -- default true
+	local stop_lsp_on_tab_leave = _opts.stop_lsp_on_tab_leave ~= false -- default true
 
 	-- Wire session.lua's save calls through our relist-aware wrapper so that
 	-- :mksession always sees all buffers across all tabs (not just the current
@@ -317,7 +318,11 @@ function M.setup(_opts)
 	vim.api.nvim_create_autocmd("TabLeave", {
 		group = augroup,
 		callback = function()
+			local tab = vim.api.nvim_get_current_tabpage()
 			unlist_all()
+			if stop_lsp_on_tab_leave then
+				require("bufstate.lsp").stop_clients_for_tab(tab)
+			end
 		end,
 	})
 


### PR DESCRIPTION
This pull request introduces a new option to control LSP client behavior when leaving a tab, enhancing session management and resource cleanup in the `lua/bufstate/init.lua` module. The main changes focus on allowing LSP clients to be stopped automatically on tab leave, improving user control and preventing unnecessary resource usage.

LSP client management improvements:

* Added the `stop_lsp_on_tab_leave` option to `M.setup`, defaulting to true, allowing users to configure whether LSP clients should be stopped when leaving a tab.
* Modified the `TabLeave` autocmd callback to stop LSP clients for the current tab if `stop_lsp_on_tab_leave` is enabled, using `require("bufstate.lsp").stop_clients_for_tab(tab)`.