### PR TITLE
Add .gitignore and fix stop LSP on tab leave wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.testenv

--- a/lua/bufstate/init.lua
+++ b/lua/bufstate/init.lua
@@ -263,6 +263,7 @@ function M.setup(_opts)
 
 	-- LSP config
 	local stop_lsp_on_session_load = _opts.stop_lsp_on_session_load ~= false -- default true
+	local stop_lsp_on_tab_leave = _opts.stop_lsp_on_tab_leave ~= false -- default true
 
 	-- Wire session.lua's save calls through our relist-aware wrapper so that
 	-- :mksession always sees all buffers across all tabs (not just the current
@@ -317,7 +318,11 @@ function M.setup(_opts)
 	vim.api.nvim_create_autocmd("TabLeave", {
 		group = augroup,
 		callback = function()
+			local tab = vim.api.nvim_get_current_tabpage()
 			unlist_all()
+			if stop_lsp_on_tab_leave then
+				require("bufstate.lsp").stop_clients_for_tab(tab)
+			end
 		end,
 	})
 


### PR DESCRIPTION
This pull request introduces an enhancement to the buffer state management in Neovim by allowing LSP clients to be stopped automatically when leaving a tab. This provides finer control over LSP client lifecycle and can help optimize resource usage during multi-tab editing sessions.

LSP client lifecycle improvements:

* Added a new option `stop_lsp_on_tab_leave` to the `M.setup` function in `lua/bufstate/init.lua`, defaulting to `true`, which enables stopping LSP clients when leaving a tab.
* Updated the `TabLeave` autocmd callback in `lua/bufstate/init.lua` to stop LSP clients for the current tab if `stop_lsp_on_tab_leave` is enabled.