### PR TITLE
Fix for dropping files (warning: generated by codex)

### DIFF
--- a/lua/bufstate/init.lua
+++ b/lua/bufstate/init.lua
@@ -42,32 +42,135 @@ local function unlist_all()
 	filtering = false
 end
 
+local function normalized_buf_path(name)
+	if not name or name == "" then
+		return nil
+	end
+	local path = vim.fn.fnamemodify(name, ":p")
+	if path == "" then
+		return nil
+	end
+	if vim.fs and vim.fs.normalize then
+		path = vim.fs.normalize(path)
+	end
+	if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+		path = path:lower()
+	end
+	return path
+end
+
+local function collect_session_buffers()
+	local result = {}
+	for tab_index, tab in ipairs(vim.api.nvim_list_tabpages()) do
+		local paths = {}
+		local seen = {}
+		for _, buf in ipairs(state.get(tab)) do
+			if vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].buftype == "" then
+				local path = normalized_buf_path(vim.api.nvim_buf_get_name(buf))
+				if path and not seen[path] then
+					seen[path] = true
+					paths[#paths + 1] = path
+				end
+			end
+		end
+		result[tab_index] = paths
+	end
+	return result
+end
+
+local function append_session_buffers(name, buffers_by_tab)
+	local path = storage.session_path(name)
+	local file, err = io.open(path, "ab")
+	if not file then
+		error("Failed to append bufstate metadata for session '" .. name .. "': " .. (err or "unknown error"))
+	end
+	file:write('" bufstate.nvim metadata: tab buffer ownership\n')
+	file:write("lua << BSTATE_EOF\n")
+	file:write("vim.g.bufstate_session_buffers = ")
+	file:write(vim.inspect(buffers_by_tab))
+	file:write("\nBSTATE_EOF\n")
+	file:close()
+end
+
+local function restore_session_buffers_from_metadata(tabs)
+	local saved = vim.g.bufstate_session_buffers
+	if type(saved) ~= "table" then
+		return false
+	end
+
+	local buffers_by_path = {}
+	for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].buftype == "" then
+			local path = normalized_buf_path(vim.api.nvim_buf_get_name(buf))
+			if path then
+				buffers_by_path[path] = buf
+			end
+		end
+	end
+
+	local restored = false
+	for tab_index, paths in pairs(saved) do
+		local tab = tabs[tonumber(tab_index)]
+		if tab and type(paths) == "table" then
+			for _, path in ipairs(paths) do
+				local buf = buffers_by_path[normalized_buf_path(path)]
+				if buf then
+					state.add(tab, buf)
+					restored = true
+				end
+			end
+		end
+	end
+	return restored
+end
+
+local function add_all_normal_buffers_to_tab(tab)
+	for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+		if
+			vim.api.nvim_buf_is_valid(buf)
+			and vim.bo[buf].buftype == ""
+			and vim.api.nvim_buf_get_name(buf) ~= ""
+		then
+			state.add(tab, buf)
+		end
+	end
+end
+
 --- Rebuild state.db from the live tab/window layout after a session load.
---- This is the authoritative post-load source of tab→buffer assignment:
+--- New bufstate session files carry explicit tab->buffer metadata, which is
+--- authoritative. Older session files fall back to the native window layout:
 ---   • Window buffers  — nvim_win_get_buf (the buffer visible in the window)
----   • Alternate bufs  — bufnr('#') inside each window (records balt entries
----                       that :mksession writes for background buffers)
+---   • Alternate bufs  — bufnr('#') inside each window (best-effort only)
 --- All tabs a buffer appears in are recorded (a buffer in two tabs → owned by both).
 ---@param restart_lsp boolean
 local function post_load_rebuild(restart_lsp)
 	state.reset()
 	local tabs = vim.api.nvim_list_tabpages()
-	for _, tab in ipairs(tabs) do
-		local wins = vim.api.nvim_tabpage_list_wins(tab)
-		for _, win in ipairs(wins) do
-			-- Primary buffer displayed in this window
-			local buf = vim.api.nvim_win_get_buf(win)
-			if vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].buftype == "" then
-				state.add(tab, buf)
+	local restored_from_metadata = restore_session_buffers_from_metadata(tabs)
+	if not restored_from_metadata then
+		for _, tab in ipairs(tabs) do
+			local wins = vim.api.nvim_tabpage_list_wins(tab)
+			for _, win in ipairs(wins) do
+				-- Primary buffer displayed in this window
+				local buf = vim.api.nvim_win_get_buf(win)
+				if vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].buftype == "" then
+					state.add(tab, buf)
+				end
+				-- Best-effort legacy fallback: older sessions did not contain
+				-- bufstate's explicit ownership metadata, so use Vim's alternate
+				-- buffer as a hint for hidden buffers.
+				local alt = vim.api.nvim_win_call(win, function()
+					return vim.fn.bufnr("#")
+				end)
+				if alt and alt > 0 and vim.api.nvim_buf_is_valid(alt) and vim.bo[alt].buftype == "" then
+					state.add(tab, alt)
+				end
 			end
-			-- Alternate buffer for this window (set by `balt` in the session file —
-			-- this is how :mksession records background/non-windowed buffers per tab)
-			local alt = vim.api.nvim_win_call(win, function()
-				return vim.fn.bufnr("#")
-			end)
-			if alt and alt > 0 and vim.api.nvim_buf_is_valid(alt) and vim.bo[alt].buftype == "" then
-				state.add(tab, alt)
-			end
+		end
+		if #tabs == 1 then
+			-- Older bufstate sessions only have :mksession's global badd preamble.
+			-- In a single-tab session every normal named buffer belongs to that tab.
+			add_all_normal_buffers_to_tab(tabs[1])
 		end
 	end
 	local current_tab = vim.api.nvim_get_current_tabpage()
@@ -101,9 +204,16 @@ end
 --- Raises on failure (same contract as storage.save).
 ---@param name string
 local function do_save(name)
+	local buffers_by_tab = collect_session_buffers()
 	relist_all_for_save()
-	storage.save(name) -- raises on failure
+	local ok, err = pcall(function()
+		storage.save(name) -- raises on failure
+		append_session_buffers(name, buffers_by_tab)
+	end)
 	filter_for_tab(vim.api.nvim_get_current_tabpage())
+	if not ok then
+		error(err, 0)
+	end
 	session.current = name
 end
 

--- a/lua/bufstate/init.lua
+++ b/lua/bufstate/init.lua
@@ -86,14 +86,15 @@ local function append_session_buffers(name, buffers_by_tab)
 	end
 	file:write('" bufstate.nvim metadata: tab buffer ownership\n')
 	file:write("lua << BSTATE_EOF\n")
-	file:write("vim.g.bufstate_session_buffers = ")
+	file:write('require("bufstate.storage")._loaded_session_buffers = ')
 	file:write(vim.inspect(buffers_by_tab))
 	file:write("\nBSTATE_EOF\n")
 	file:close()
 end
 
 local function restore_session_buffers_from_metadata(tabs)
-	local saved = vim.g.bufstate_session_buffers
+	local saved = storage._loaded_session_buffers
+	storage._loaded_session_buffers = nil
 	if type(saved) ~= "table" then
 		return false
 	end
@@ -109,11 +110,12 @@ local function restore_session_buffers_from_metadata(tabs)
 	end
 
 	local restored = false
-	for tab_index, paths in pairs(saved) do
-		local tab = tabs[tonumber(tab_index)]
+	for tab_index, paths in ipairs(saved) do
+		local tab = tabs[tab_index]
 		if tab and type(paths) == "table" then
-			for _, path in ipairs(paths) do
-				local buf = buffers_by_path[normalized_buf_path(path)]
+			for _, saved_path in ipairs(paths) do
+				local normalized_path = normalized_buf_path(saved_path)
+				local buf = normalized_path and buffers_by_path[normalized_path]
 				if buf then
 					state.add(tab, buf)
 					restored = true

--- a/lua/bufstate/init.lua
+++ b/lua/bufstate/init.lua
@@ -78,24 +78,9 @@ local function collect_session_buffers()
 	return result
 end
 
-local function append_session_buffers(name, buffers_by_tab)
-	local path = storage.session_path(name)
-	local file, err = io.open(path, "ab")
-	if not file then
-		error("Failed to append bufstate metadata for session '" .. name .. "': " .. (err or "unknown error"))
-	end
-	file:write('" bufstate.nvim metadata: tab buffer ownership\n')
-	file:write("lua << BSTATE_EOF\n")
-	file:write('require("bufstate.storage")._loaded_session_buffers = ')
-	file:write(vim.inspect(buffers_by_tab))
-	file:write("\nBSTATE_EOF\n")
-	file:close()
-end
-
-local function restore_session_buffers_from_metadata(tabs)
-	local saved = storage._loaded_session_buffers
-	storage._loaded_session_buffers = nil
-	if type(saved) ~= "table" then
+local function restore_session_buffers_from_metadata(name, tabs)
+	local saved = storage.load_metadata(name)
+	if vim.tbl_isempty(saved) then
 		return false
 	end
 
@@ -139,16 +124,18 @@ local function add_all_normal_buffers_to_tab(tab)
 end
 
 --- Rebuild state.db from the live tab/window layout after a session load.
---- New bufstate session files carry explicit tab->buffer metadata, which is
---- authoritative. Older session files fall back to the native window layout:
+--- New bufstate sessions carry an explicit tab->buffer ownership sidecar, which
+--- is authoritative. Older sessions without a sidecar fall back to the native
+--- window layout:
 ---   • Window buffers  — nvim_win_get_buf (the buffer visible in the window)
 ---   • Alternate bufs  — bufnr('#') inside each window (best-effort only)
 --- All tabs a buffer appears in are recorded (a buffer in two tabs → owned by both).
+---@param name string
 ---@param restart_lsp boolean
-local function post_load_rebuild(restart_lsp)
+local function post_load_rebuild(name, restart_lsp)
 	state.reset()
 	local tabs = vim.api.nvim_list_tabpages()
-	local restored_from_metadata = restore_session_buffers_from_metadata(tabs)
+	local restored_from_metadata = restore_session_buffers_from_metadata(name, tabs)
 	if not restored_from_metadata then
 		for _, tab in ipairs(tabs) do
 			local wins = vim.api.nvim_tabpage_list_wins(tab)
@@ -210,7 +197,7 @@ local function do_save(name)
 	relist_all_for_save()
 	local ok, err = pcall(function()
 		storage.save(name) -- raises on failure
-		append_session_buffers(name, buffers_by_tab)
+		storage.save_metadata(name, buffers_by_tab) -- raises on failure
 	end)
 	filter_for_tab(vim.api.nvim_get_current_tabpage())
 	if not ok then
@@ -549,7 +536,7 @@ function M.setup(_opts)
 			if not ok then
 				vim.notify(err or "Failed to load session", vim.log.levels.ERROR)
 			else
-				post_load_rebuild(stop_lsp_on_session_load)
+				post_load_rebuild(name, stop_lsp_on_session_load)
 				vim.notify("Session loaded: " .. name, vim.log.levels.INFO)
 			end
 		end
@@ -674,7 +661,7 @@ function M.setup(_opts)
 				if not ok then
 					vim.notify("Failed to auto-load session: " .. (err or ""), vim.log.levels.WARN)
 				else
-					post_load_rebuild(stop_lsp_on_session_load)
+					post_load_rebuild(name, stop_lsp_on_session_load)
 					vim.notify("Session auto-loaded: " .. name, vim.log.levels.INFO)
 				end
 			end

--- a/lua/bufstate/storage.lua
+++ b/lua/bufstate/storage.lua
@@ -64,7 +64,12 @@ function M.save_metadata(name, buffers_by_tab)
 	local path = M.metadata_path(name)
 	local file, open_err = io.open(path, "w")
 	if not file then
-		error("Failed to write bufstate metadata for session '" .. name .. "': " .. (open_err or "unknown error"))
+		error(
+			"Failed to write bufstate metadata for session '"
+				.. name
+				.. "': "
+				.. (open_err or "unknown error")
+		)
 	end
 	file:write(vim.json.encode({ version = 1, tabs = buffers_by_tab }))
 	file:close()

--- a/lua/bufstate/storage.lua
+++ b/lua/bufstate/storage.lua
@@ -19,6 +19,16 @@ function M.session_path(name)
 	return M.session_dir() .. "/" .. name .. ".vim"
 end
 
+--- Path to the sidecar file holding bufstate's tab→buffer ownership map.
+--- Kept separate from the `.vim` session so the session file stays pure
+--- native :mksession output (sourceable on its own) and the ownership data
+--- is inert JSON rather than executable Lua. Does not collide with M.list(),
+--- which globs only `*.vim`.
+---@param name string
+function M.metadata_path(name)
+	return M.session_dir() .. "/" .. name .. ".bufstate.json"
+end
+
 function M.last_loaded_path()
 	return M.session_dir() .. "/.last_loaded"
 end
@@ -45,6 +55,42 @@ function M.save(name)
 	return true
 end
 
+--- Persist bufstate's tab→buffer ownership map alongside the session file.
+--- buffers_by_tab is a 1-based array where entry i holds the absolute, normalized
+--- buffer paths owned by the i-th tab.
+---@param name string
+---@param buffers_by_tab string[][]
+function M.save_metadata(name, buffers_by_tab)
+	local path = M.metadata_path(name)
+	local file, open_err = io.open(path, "w")
+	if not file then
+		error("Failed to write bufstate metadata for session '" .. name .. "': " .. (open_err or "unknown error"))
+	end
+	file:write(vim.json.encode({ version = 1, tabs = buffers_by_tab }))
+	file:close()
+	return true
+end
+
+--- Read the tab→buffer ownership map for a session.
+--- Returns the `tabs` array, or an empty table when the sidecar is missing or
+--- unreadable (Null Object — callers never need to nil-check; an empty result
+--- transparently triggers the legacy reconstruction fallback).
+---@param name string
+---@return string[][]
+function M.load_metadata(name)
+	local file = io.open(M.metadata_path(name), "r")
+	if not file then
+		return {}
+	end
+	local contents = file:read("*all")
+	file:close()
+	local ok, decoded = pcall(vim.json.decode, contents)
+	if not ok or type(decoded) ~= "table" or type(decoded.tabs) ~= "table" then
+		return {}
+	end
+	return decoded.tabs
+end
+
 --- Source a named session file.
 ---@param name string
 ---@return boolean ok, string|nil err
@@ -53,10 +99,6 @@ function M.load(name)
 	if vim.fn.filereadable(path) == 0 then
 		return false, "Session not found: " .. name
 	end
-
-	-- Avoid reusing ownership metadata from a previously sourced session when
-	-- loading older session files that do not contain a bufstate metadata block.
-	M._loaded_session_buffers = nil
 
 	-- Close all floating windows before sourcing. The session file contains an
 	-- `only` command that closes all but one window; if the only remaining window
@@ -96,6 +138,8 @@ function M.delete(name)
 		return false, "Session not found: " .. name
 	end
 	vim.fn.delete(path)
+	-- Remove the ownership sidecar too; ignore if it was never written.
+	vim.fn.delete(M.metadata_path(name))
 	return true
 end
 

--- a/lua/bufstate/storage.lua
+++ b/lua/bufstate/storage.lua
@@ -56,7 +56,7 @@ function M.load(name)
 
 	-- Avoid reusing ownership metadata from a previously sourced session when
 	-- loading older session files that do not contain a bufstate metadata block.
-	vim.g.bufstate_session_buffers = nil
+	M._loaded_session_buffers = nil
 
 	-- Close all floating windows before sourcing. The session file contains an
 	-- `only` command that closes all but one window; if the only remaining window

--- a/lua/bufstate/storage.lua
+++ b/lua/bufstate/storage.lua
@@ -29,7 +29,16 @@ end
 ---@param name string
 function M.save(name)
 	local path = M.session_path(name)
+	local save_sessionoptions = vim.o.sessionoptions
+	local opts = vim.opt.sessionoptions:get()
+	for _, required in ipairs({ "buffers", "tabpages" }) do
+		if not vim.tbl_contains(opts, required) then
+			vim.opt.sessionoptions:append(required)
+		end
+	end
+
 	local ok, err = pcall(vim.cmd, "mksession! " .. vim.fn.fnameescape(path))
+	vim.o.sessionoptions = save_sessionoptions
 	if not ok then
 		error("Failed to save session '" .. name .. "': " .. (err or "unknown error"))
 	end
@@ -44,6 +53,10 @@ function M.load(name)
 	if vim.fn.filereadable(path) == 0 then
 		return false, "Session not found: " .. name
 	end
+
+	-- Avoid reusing ownership metadata from a previously sourced session when
+	-- loading older session files that do not contain a bufstate metadata block.
+	vim.g.bufstate_session_buffers = nil
 
 	-- Close all floating windows before sourcing. The session file contains an
 	-- `only` command that closes all but one window; if the only remaining window


### PR DESCRIPTION
I recently (probably after recent round of updates in bufstate.nvim) started experiencing issues with how sessions were saved, where many of the files stored in the saved session would not get retrieved on session load.

More concrete example:
* only one tab open, open 4 random files
* save session and close nvim
* reopen nvim and load the saved session
* only two files get reopened

at least that was my experience.
I asked codex to fix this and it produced the changes submitted as PR here. I don't know much lua and bufstate internals to make sure that these changes make sense code-wise. But the issue I experienced is no longer present and session files are recovered correctly for me.

I tried to make codex clean up after itself and make sure the changes are not invasive, but I'm not sure if I succeeded. This is a description of changes that I managed to squeeze out of it, but it seemed to change perspective a bit depending on my arguments (I was not convinced by his early description of the fixes), so I'm not sure how much of the code in this PR is a direct fix to the issue I mention.

> ### Fix incomplete buffer ownership restore after loading sessions
>  
> Saved sessions could contain all expected buffers, and the session picker could
list them correctly, but after loading only some buffers were restored into
bufstate’s tab state. This happened because bufstate suppresses `BufAdd` while
sourcing a session: native session files add buffers before tab context is
reliable. After sourcing, bufstate rebuilt ownership only from visible window
buffers and each window’s alternate buffer, which is lossy. In a single-tab
session with several opened files, that could restore only the current and
alternate buffers while leaving other saved buffers outside bufstate’s state.  
>  
> This change saves bufstate’s own tab-to-buffer ownership metadata alongside the
native session file, using normalized buffer paths. After the native session has
recreated buffers, tabs, and windows, bufstate rebuilds `state.db` from that
metadata instead of guessing from the window layout. The previous
window/alternate-buffer reconstruction remains as a fallback for older sessions.  
>  
> The save path also temporarily relists buffers known to bufstate and ensures
`sessionoptions` includes `buffers` and `tabpages`, so the native session file
contains the buffers and tabs needed for ownership metadata to resolve on load.  

Sorry, I couldn't make it easier for you to review, but I reasoned it might be better to bring this issue (and potential fix) to your attention than to leave it laying in my local changes.