### PR TITLE
ci: add versioning, release, and lint workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  stylua:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install stylua
+        uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          args: --check .

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,39 @@
+name: PR Validation
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+    branches: [main]
+
+jobs:
+  validate-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check version label
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          REQUIRED=("documentation" "major" "minor" "patch")
+          PRESENT=()
+
+          for label in "${REQUIRED[@]}"; do
+            count=$(echo "$LABELS" | jq --arg lb "$label" 'map(select(. == $lb)) | length')
+            if [[ "$count" -gt 0 ]]; then
+              PRESENT+=("$label")
+            fi
+          done
+
+          if [[ ${#PRESENT[@]} -eq 0 ]]; then
+            echo "::error::Missing version label. Add one of: documentation, major, minor, patch."
+            exit 1
+          fi
+
+          if [[ ${#PRESENT[@]} -gt 1 ]]; then
+            CONFLICTING=$(printf "'%s', " "${PRESENT[@]}" | sed 's/, $//')
+            echo "::error::Conflicting version labels: ${CONFLICTING}. Use only one of: documentation, major, minor, patch."
+            exit 1
+          fi
+
+          echo "Version label set to: ${PRESENT[0]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  version:
+    uses: ./.github/workflows/version.yml
+    secrets: inherit
+
+  release:
+    needs: version
+    if: needs.version.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ needs.version.outputs.version }}"
+          git push origin "v${{ needs.version.outputs.version }}"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.version.outputs.version }}
+          name: v${{ needs.version.outputs.version }}
+          generate_release_notes: true

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,71 @@
+name: Calculate Version
+
+on:
+  workflow_call:
+    outputs:
+      version:
+        description: "The calculated semantic version (e.g. 1.2.3)"
+        value: ${{ jobs.version.outputs.version }}
+      should_publish:
+        description: "Whether a release should be published"
+        value: ${{ jobs.version.outputs.should_publish }}
+
+jobs:
+  version:
+    if: >-
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.labels.*.name, 'documentation')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.calc.outputs.VERSION }}
+      should_publish: ${{ steps.calc.outputs.SHOULD_PUBLISH }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: main
+      - name: Calculate next version
+        id: calc
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [[ -n "$LATEST_TAG" ]]; then
+            CURRENT_VERSION=$(echo "$LATEST_TAG" | sed 's/^[^0-9]*//')
+          else
+            CURRENT_VERSION="0.0.0"
+          fi
+          if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not parse version from tag '$LATEST_TAG'. Falling back to 0.0.0"
+            CURRENT_VERSION="0.0.0"
+          fi
+          echo "Current version: $CURRENT_VERSION"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+          HAS_MAJOR=$(echo "$PR_LABELS" | jq 'map(select(. == "major")) | length')
+          HAS_MINOR=$(echo "$PR_LABELS" | jq 'map(select(. == "minor")) | length')
+          HAS_PATCH=$(echo "$PR_LABELS" | jq 'map(select(. == "patch")) | length')
+          if [[ "$HAS_MAJOR" -gt 0 ]]; then
+            echo "Major version bump"
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif [[ "$HAS_MINOR" -gt 0 ]]; then
+            echo "Minor version bump"
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          elif [[ "$HAS_PATCH" -gt 0 ]]; then
+            echo "Patch version bump"
+            PATCH=$((PATCH + 1))
+          else
+            echo "No version label found (major/minor/patch). Skipping release."
+            echo "SHOULD_PUBLISH=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "New version: $NEW_VERSION"
+          echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "SHOULD_PUBLISH=true" >> $GITHUB_OUTPUT

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,3 @@
+indent_type = "Tabs"
+indent_width = 1
+column_width = 100

--- a/lua/bufstate/init.lua
+++ b/lua/bufstate/init.lua
@@ -181,7 +181,8 @@ local function db_snapshot()
 	end
 	for tab in pairs(state.db) do
 		if not live[tab] then
-			lines[#lines + 1] = string.format("  tab %d (dead): %d buf(s)", tab, vim.tbl_count(state.db[tab]))
+			lines[#lines + 1] =
+				string.format("  tab %d (dead): %d buf(s)", tab, vim.tbl_count(state.db[tab]))
 		end
 	end
 

--- a/lua/bufstate/ui.lua
+++ b/lua/bufstate/ui.lua
@@ -13,11 +13,14 @@ function M.prompt_session_name(callback, opts)
 	opts = opts or {}
 	local ok, snacks = pcall(require, "snacks")
 	if not ok then
-		vim.ui.input({ prompt = opts.prompt or "Session name: ", default = opts.default or "" }, function(value)
-			if value and value ~= "" then
-				callback(value)
+		vim.ui.input(
+			{ prompt = opts.prompt or "Session name: ", default = opts.default or "" },
+			function(value)
+				if value and value ~= "" then
+					callback(value)
+				end
 			end
-		end)
+		)
 		return
 	end
 


### PR DESCRIPTION
## Changes

- **version.yml** — Reusable workflow that calculates the next semantic version from the latest git tag and PR labels (`major`/`minor`/`patch`). Skips release when `documentation` label is present. Falls back to `0.0.0` when no tags exist.
- **release.yml** — Triggers on PR merge to `main`. Calls the version workflow, pushes a `vX.Y.Z` tag, and creates a GitHub Release with auto-generated release notes.
- **lint.yml** — Runs `stylua --check .` on PRs to `main` to enforce code formatting.
- **.stylua.toml** — Formatter config matching existing code style (tabs, indent_width=1, column_width=100).