### PR TITLE
feat: add :BufstateClose command and clarify exit behavior (fixes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Do this:
 " Save your workspace
 :BufstateSave myworkspace
 
+" Exit Neovim — session auto-saves on exit (VimLeavePre).
+" Use :qall, close the terminal — whatever you prefer.
+
 " Next day: restore instantly
 :BufstateLoad myworkspace
 " Or just open Neovim — auto-loads last session if configured!
@@ -189,7 +192,8 @@ Do this:
    - Press `<leader>qs` to quick-save
    - Auto-saves happen every 5 minutes
 
-4. **Tomorrow:**
+4. **End of day / Tomorrow:**
+   - Exit Neovim (`:qall`, close terminal, etc.) — session auto-saves on exit
    - Open Neovim
    - Everything auto-restores — tabs, buffers, window splits, even cursor positions
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ https://github.com/user-attachments/assets/9162f9a5-8576-4f95-b01b-0f2a1ab10f17
 - **Load** (`BufstateLoad`) — Restores a session interactively via fuzzy picker
 - **Delete** (`BufstateDelete`) — Removes a session with picker confirmation
 - **New** (`BufstateNew`) — Saves the current workspace, then clears everything for a fresh start
+- **Close** (`BufstateClose`) — Saves the current workspace and closes it, leaving a clean slate. Follow up with `:BufstateLoad` to switch context.
 - **List** (`BufstateList`) — Shows all saved sessions with timestamps and current marker
 - **Auto-load on startup** — Optionally restores the last used session when Neovim opens
 - **Interactive picker** — Fuzzy-search through sessions with preview (snacks.nvim integration, falls back to `vim.ui.select`)
@@ -224,6 +225,7 @@ vim.g.bufstate_no_default_maps = 1
 | `:BufstateLoad`   | `[name]`  | Load a session (shows picker if no name)        |
 | `:BufstateDelete` | `[name]`  | Delete a session (shows picker if no name)      |
 | `:BufstateNew`    | `[name]`  | Save current, then start a fresh workspace      |
+| `:BufstateClose`  | None      | Save current and close workspace (clears buffers/tabs) |
 | `:BufstateList`   | None      | List all sessions with timestamps and marker    |
 
 ### Safe Delete Commands

--- a/lua/bufstate/init.lua
+++ b/lua/bufstate/init.lua
@@ -600,6 +600,12 @@ function M.setup(_opts)
 		end
 	end, { nargs = "?", desc = "Start a new session (saves current first)" })
 
+	-- :BufstateClose — save current then wipe everything, leave a clean workspace
+	vim.api.nvim_create_user_command("BufstateClose", function()
+		session.close()
+		vim.notify("Workspace closed — use :BufstateLoad to open another session", vim.log.levels.INFO)
+	end, { desc = "Save current workspace and close it (clears buffers and tabs)" })
+
 	-- :BufstateList — print all sessions
 	vim.api.nvim_create_user_command("BufstateList", function()
 		local sessions = storage.list()

--- a/lua/bufstate/session.lua
+++ b/lua/bufstate/session.lua
@@ -110,6 +110,26 @@ function M.new(name)
 	return true
 end
 
+--- Save current workspace, wipe all buffers and tabs, leave a clean slate.
+--- Does not prompt — the user can follow up with :BufstateLoad to switch context.
+function M.close()
+	if M.current then
+		pcall(M.save, M.current)
+	else
+		pcall(M.save, "_autosave")
+	end
+
+	clear_buffers()
+
+	local tabs = vim.api.nvim_list_tabpages()
+	for i = #tabs, 2, -1 do
+		pcall(vim.api.nvim_set_current_tabpage, tabs[i])
+		pcall(vim.cmd, "tabclose!")
+	end
+
+	M.current = nil
+end
+
 --- List all saved sessions.
 ---@return { name: string, path: string, mtime: integer }[]
 function M.list()


### PR DESCRIPTION
Closes #8.

## Summary

Issue #8 asked: "What is the appropriate way to close the current NeoVim session? How to exit without losing the workspace?"

Two changes address this:

### 1. Documentation — clarify exit behavior

The README workflow went straight from "save" to "next day: restore" without explaining what happened in between. Added an explicit "Exit Neovim" step explaining that `VimLeavePre` auto-save persists the session regardless of how you close (`:qall`, closing the terminal, etc.).

### 2. `:BufstateClose` — new command

A command that closes the current workspace without leaving Neovim:

- Saves the current session (falls back to `_autosave` if unnamed)
- Wipes all normal buffers
- Closes all extra tab pages
- Prints a hint to use `:BufstateLoad` to switch context

This complements `:BufstateNew` (which saves current, clears, and prompts for a new session name) by providing a simpler "just close it" variant.