### PR TITLE
feat: add <leader>qc keymap for :BufstateClose

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Do this:
 | `<leader>ql` | `:BufstateLoad`   | Load session (picker)                         |
 | `<leader>qd` | `:BufstateDelete` | Delete session (picker)                       |
 | `<leader>qn` | `:BufstateNew`    | New session (saves current, clears workspace) |
+| `<leader>qc` | `:BufstateClose`  | Close workspace (save + clear buffers/tabs)   |
 
 Disable all default keymaps:
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ return {
   --   { "<leader>ql", "<cmd>BufstateLoad<CR>",   desc = "Load session" },
   --   { "<leader>qd", "<cmd>BufstateDelete<CR>", desc = "Delete session" },
   --   { "<leader>qn", "<cmd>BufstateNew<CR>",    desc = "New session" },
+  --   { "<leader>qc", "<cmd>BufstateClose<CR>", desc = "Close workspace" },
   -- },
 }
 

--- a/plugin/bufstate.lua
+++ b/plugin/bufstate.lua
@@ -22,4 +22,5 @@ if not vim.g.bufstate_no_default_maps then
 	vim.keymap.set("n", "<leader>ql", ":BufstateLoad<CR>", { desc = "Load session" })
 	vim.keymap.set("n", "<leader>qd", ":BufstateDelete<CR>", { desc = "Delete session" })
 	vim.keymap.set("n", "<leader>qn", ":BufstateNew<CR>", { desc = "New session" })
+	vim.keymap.set("n", "<leader>qc", ":BufstateClose<CR>", { desc = "Close workspace" })
 end


### PR DESCRIPTION
Adds the default `<leader>qc` keymap for the `:BufstateClose` command (introduced in #18). Also adds it to the commented-out keymap override example in the README.

## Changes

| File | Change |
|---|---|
| `plugin/bufstate.lua` | Register `<leader>qc` default keymap |
| `README.md` | Add `<leader>qc` to Default Keymaps table and commented override example |

Depends on #18 being merged first. Fixes #8.