### PR TITLE
feat: add :BufstateAlternate command to toggle between last sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ https://github.com/user-attachments/assets/9162f9a5-8576-4f95-b01b-0f2a1ab10f17
 - **Close** (`BufstateClose`) — Saves the current workspace and closes it, leaving a clean slate. Follow up with `:BufstateLoad` to switch context.
 - **List** (`BufstateList`) — Shows all saved sessions with timestamps and current marker
 - **Auto-load on startup** — Optionally restores the last used session when Neovim opens
+- **Alternate session** (`BufstateAlternate`) — Toggle between the last two sessions with one key, like tmux's `prefix + L`
 - **Interactive picker** — Fuzzy-search through sessions with preview (snacks.nvim integration, falls back to `vim.ui.select`)
 - **Multiple named sessions** — Maintain as many independent sessions as you need
 
@@ -121,6 +122,7 @@ return {
   --   { "<leader>qd", "<cmd>BufstateDelete<CR>", desc = "Delete session" },
   --   { "<leader>qn", "<cmd>BufstateNew<CR>",    desc = "New session" },
   --   { "<leader>qc", "<cmd>BufstateClose<CR>", desc = "Close workspace" },
+  --   { "<leader>qa", "<cmd>BufstateAlternate<CR>", desc = "Alternate session" },
   -- },
 }
 
@@ -209,6 +211,7 @@ Do this:
 | `<leader>qd` | `:BufstateDelete` | Delete session (picker)                       |
 | `<leader>qn` | `:BufstateNew`    | New session (saves current, clears workspace) |
 | `<leader>qc` | `:BufstateClose`  | Close workspace (save + clear buffers/tabs)   |
+| `<leader>qa` | `:BufstateAlternate` | Load previous session (toggle)           |
 
 Disable all default keymaps:
 
@@ -228,6 +231,7 @@ vim.g.bufstate_no_default_maps = 1
 | `:BufstateDelete` | `[name]`  | Delete a session (shows picker if no name)      |
 | `:BufstateNew`    | `[name]`  | Save current, then start a fresh workspace      |
 | `:BufstateClose`  | None      | Save current and close workspace (clears buffers/tabs) |
+| `:BufstateAlternate` | None   | Load the previously active session (toggle)          |
 | `:BufstateList`   | None      | List all sessions with timestamps and marker    |
 
 ### Safe Delete Commands

--- a/lua/bufstate/init.lua
+++ b/lua/bufstate/init.lua
@@ -606,6 +606,16 @@ function M.setup(_opts)
 		vim.notify("Workspace closed — use :BufstateLoad to open another session", vim.log.levels.INFO)
 	end, { desc = "Save current workspace and close it (clears buffers and tabs)" })
 
+	-- :BufstateAlternate — load the previously active session (toggle)
+	vim.api.nvim_create_user_command("BufstateAlternate", function()
+		local ok, err = session.alternate()
+		if not ok then
+			vim.notify(err or "Failed to load alternate session", vim.log.levels.WARN)
+		else
+			vim.notify("Alternate session loaded: " .. session.current, vim.log.levels.INFO)
+		end
+	end, { desc = "Load the previously active session (toggle between last two)" })
+
 	-- :BufstateList — print all sessions
 	vim.api.nvim_create_user_command("BufstateList", function()
 		local sessions = storage.list()

--- a/lua/bufstate/session.lua
+++ b/lua/bufstate/session.lua
@@ -15,6 +15,9 @@ local M = {}
 -- Current session name (nil = unsaved / no session active)
 M.current = nil
 
+-- Previously active session name (nil = no alternate to switch to)
+M.previous = nil
+
 -- Injected by init.lua; wraps storage.save() with the buflisted relist sandwich
 local save_fn = nil
 
@@ -76,6 +79,7 @@ function M.load(name)
 		return false, err
 	end
 
+	M.previous = M.current
 	M.current = name
 	storage.save_last_loaded(name)
 	return true
@@ -128,6 +132,16 @@ function M.close()
 	end
 
 	M.current = nil
+end
+
+--- Load the previously active session (toggle between last two).
+--- Calls M.load(), which saves current and tracks the swap.
+---@return boolean ok, string|nil err
+function M.alternate()
+	if not M.previous then
+		return false, "No alternate session available"
+	end
+	return M.load(M.previous)
 end
 
 --- List all saved sessions.

--- a/lua/bufstate/storage.lua
+++ b/lua/bufstate/storage.lua
@@ -109,7 +109,7 @@ function M.load(name)
 	-- `only` command that closes all but one window; if the only remaining window
 	-- is a floating one Neovim raises E5601. Closing floats first avoids this.
 	for _, win in ipairs(vim.api.nvim_list_wins()) do
-		if vim.api.nvim_win_get_config(win).relative ~= "" then
+		if vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_config(win).relative ~= "" then
 			pcall(vim.api.nvim_win_close, win, true)
 		end
 	end

--- a/plugin/bufstate.lua
+++ b/plugin/bufstate.lua
@@ -16,12 +16,12 @@ vim.api.nvim_create_autocmd("VimEnter", {
 })
 
 -- Default keymaps (disable with vim.g.bufstate_no_default_maps = 1)
-	if not vim.g.bufstate_no_default_maps then
-		vim.keymap.set("n", "<leader>qs", ":BufstateSave<CR>", { desc = "Save session" })
-		vim.keymap.set("n", "<leader>qS", ":BufstateSaveAs<CR>", { desc = "Save session as" })
-		vim.keymap.set("n", "<leader>ql", ":BufstateLoad<CR>", { desc = "Load session" })
-		vim.keymap.set("n", "<leader>qd", ":BufstateDelete<CR>", { desc = "Delete session" })
-		vim.keymap.set("n", "<leader>qn", ":BufstateNew<CR>", { desc = "New session" })
-		vim.keymap.set("n", "<leader>qc", ":BufstateClose<CR>", { desc = "Close workspace" })
-		vim.keymap.set("n", "<leader>qa", ":BufstateAlternate<CR>", { desc = "Alternate session" })
-	end
+if not vim.g.bufstate_no_default_maps then
+	vim.keymap.set("n", "<leader>qs", ":BufstateSave<CR>", { desc = "Save session" })
+	vim.keymap.set("n", "<leader>qS", ":BufstateSaveAs<CR>", { desc = "Save session as" })
+	vim.keymap.set("n", "<leader>ql", ":BufstateLoad<CR>", { desc = "Load session" })
+	vim.keymap.set("n", "<leader>qd", ":BufstateDelete<CR>", { desc = "Delete session" })
+	vim.keymap.set("n", "<leader>qn", ":BufstateNew<CR>", { desc = "New session" })
+	vim.keymap.set("n", "<leader>qc", ":BufstateClose<CR>", { desc = "Close workspace" })
+	vim.keymap.set("n", "<leader>qa", ":BufstateAlternate<CR>", { desc = "Alternate session" })
+end

--- a/plugin/bufstate.lua
+++ b/plugin/bufstate.lua
@@ -16,11 +16,12 @@ vim.api.nvim_create_autocmd("VimEnter", {
 })
 
 -- Default keymaps (disable with vim.g.bufstate_no_default_maps = 1)
-if not vim.g.bufstate_no_default_maps then
-	vim.keymap.set("n", "<leader>qs", ":BufstateSave<CR>", { desc = "Save session" })
-	vim.keymap.set("n", "<leader>qS", ":BufstateSaveAs<CR>", { desc = "Save session as" })
-	vim.keymap.set("n", "<leader>ql", ":BufstateLoad<CR>", { desc = "Load session" })
-	vim.keymap.set("n", "<leader>qd", ":BufstateDelete<CR>", { desc = "Delete session" })
-	vim.keymap.set("n", "<leader>qn", ":BufstateNew<CR>", { desc = "New session" })
-	vim.keymap.set("n", "<leader>qc", ":BufstateClose<CR>", { desc = "Close workspace" })
-end
+	if not vim.g.bufstate_no_default_maps then
+		vim.keymap.set("n", "<leader>qs", ":BufstateSave<CR>", { desc = "Save session" })
+		vim.keymap.set("n", "<leader>qS", ":BufstateSaveAs<CR>", { desc = "Save session as" })
+		vim.keymap.set("n", "<leader>ql", ":BufstateLoad<CR>", { desc = "Load session" })
+		vim.keymap.set("n", "<leader>qd", ":BufstateDelete<CR>", { desc = "Delete session" })
+		vim.keymap.set("n", "<leader>qn", ":BufstateNew<CR>", { desc = "New session" })
+		vim.keymap.set("n", "<leader>qc", ":BufstateClose<CR>", { desc = "Close workspace" })
+		vim.keymap.set("n", "<leader>qa", ":BufstateAlternate<CR>", { desc = "Alternate session" })
+	end

--- a/tests/bufstate/session_spec.lua
+++ b/tests/bufstate/session_spec.lua
@@ -228,4 +228,47 @@ describe("bufstate.session", function()
 			assert.is_true(vim.tbl_contains(names, "second"))
 		end)
 	end)
+
+	describe("alternate", function()
+		before_each(function()
+			session.set_save_fn(function(name)
+				storage.save(name)
+				session.current = name
+			end)
+			session.save("alternate-a")
+			session.save("alternate-b")
+			session.previous = nil
+		end)
+
+		it("returns error when no previous session exists", function()
+			session.current = nil
+			session.previous = nil
+			local ok, err = session.alternate()
+			assert.is_false(ok)
+			assert.is_not_nil(err)
+		end)
+
+		it("loads the previous session", function()
+			local ok, err = session.load("alternate-a")
+			assert.is_true(ok, err)
+			ok, err = session.load("alternate-b")
+			assert.is_true(ok, err)
+			assert.equals("alternate-b", session.previous)
+
+			ok, err = session.alternate()
+			assert.is_true(ok, err)
+			assert.equals("alternate-a", session.current)
+		end)
+
+		it("toggles between two sessions", function()
+			session.load("alternate-a")
+			session.load("alternate-b")
+
+			session.alternate()
+			assert.equals("alternate-a", session.current)
+
+			session.alternate()
+			assert.equals("alternate-b", session.current)
+		end)
+	end)
 end)

--- a/tests/bufstate/session_spec.lua
+++ b/tests/bufstate/session_spec.lua
@@ -253,7 +253,7 @@ describe("bufstate.session", function()
 			assert.is_true(ok, err)
 			ok, err = session.load("alternate-b")
 			assert.is_true(ok, err)
-			assert.equals("alternate-b", session.previous)
+			assert.equals("alternate-a", session.previous)
 
 			ok, err = session.alternate()
 			assert.is_true(ok, err)


### PR DESCRIPTION
Closes #5.

## What

Adds `:BufstateAlternate` — a command that loads the previously active session, like tmux's `prefix + L`. Calling it again toggles back to the original session (swaps `current` ↔ `previous`).

## How it works

- `session.lua` now tracks `M.previous` — updated on every `session.load()` before overwriting `M.current`
- `M.alternate()` calls `M.load(M.previous)`, which saves current and loads the alternate
- Warns if no alternate session exists yet (need at least two session loads in this Neovim instance)

## Changes

| File | Change |
|---|---|
| `session.lua` | Add `M.previous`, set in `M.load()`, add `M.alternate()` |
| `init.lua` | Register `:BufstateAlternate` command |
| `plugin/bufstate.lua` | Add `<leader>qa` default keymap |
| `README.md` | Document in features, commands table, keymaps table, and override example |

## New keymap

| Keymap | Command | Description |
|---|---|---|
| `<leader>qa` | `:BufstateAlternate` | Load previous session (toggle) |